### PR TITLE
Fix: Correct YAML Syntax in Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         fi
         
         # Add StrictHostKeyChecking=no to avoid host key verification issues
-        ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ubuntu@"$AWS_SERVER_IP" << 'EOF'
+        ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ubuntu@"$AWS_SERVER_IP" << 'EOSSH'
           set -e  # Exit immediately if a command exits with a non-zero status
           
           echo "Stopping any existing container..."
@@ -65,7 +65,7 @@ jobs:
           docker ps | grep 3d-navi-container || { echo "Container failed to start"; exit 1; }
           
           echo "Deployment to server completed successfully"
-EOF
+        EOSSH
         
     - name: Verify Deployment
       env:


### PR DESCRIPTION
## Description
This PR fixes the YAML syntax error in the deployment workflow file.

## Changes
- Changed the heredoc terminator from EOF to EOSSH for clarity
- Properly indented the closing EOSSH terminator to match the YAML structure

## Error Fixed
This PR fixes the following error in the YAML syntax:
```
Invalid workflow file
You have an error in your yaml syntax on line 68
```

The issue was with the heredoc EOF terminator not being properly indented in the YAML file. In YAML, the closing heredoc delimiter must be properly indented to match the structure of the document.

## How to Use
No changes to usage. The deployment workflow will continue to work as expected, but now it will pass the YAML syntax validation.

@msm-amit-regmi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fb13e0e0b77e4ec8803775dc5125c4c2)