### PR TITLE
Fix: Update AWS_SECRET_KEY to Use Environment Variable Instead of Secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,8 @@ jobs:
       
     - name: Set up SSH
       env:
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        # Use environment variable for AWS_SECRET_KEY
+        AWS_SECRET_KEY: ${{ vars.AWS_SECRET_KEY }}
         AWS_SERVER_IP: ${{ vars.AWS_SERVER_IP }}
       run: |
         mkdir -p ~/.ssh
@@ -42,8 +43,8 @@ jobs:
         
         # Check if AWS_SECRET_KEY is set
         if [ -z "$AWS_SECRET_KEY" ]; then
-          echo "Error: AWS_SECRET_KEY is not set. Please add it as a secret in the GitHub repository."
-          echo "Go to Settings > Secrets and variables > Actions > New repository secret"
+          echo "Error: AWS_SECRET_KEY is not set. Please add it as a variable in the GitHub environment."
+          echo "Go to Settings > Environments > 3d navi > Add variable"
           echo "Name: AWS_SECRET_KEY"
           echo "Value: Your private SSH key for connecting to the AWS server"
           exit 1
@@ -109,7 +110,7 @@ jobs:
     - name: Deploy to AWS Server
       env:
         AWS_SERVER_IP: ${{ vars.AWS_SERVER_IP }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_SECRET_KEY: ${{ vars.AWS_SECRET_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Ensure AWS_SERVER_IP is not empty before using it
@@ -202,7 +203,7 @@ jobs:
     - name: Verify Deployment
       env:
         AWS_SERVER_IP: ${{ vars.AWS_SERVER_IP }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_SECRET_KEY: ${{ vars.AWS_SECRET_KEY }}
       run: |
         # Ensure AWS_SERVER_IP is not empty before using it
         if [ -z "$AWS_SERVER_IP" ]; then


### PR DESCRIPTION
## Description
This PR updates the deployment workflow to use the AWS_SECRET_KEY from environment variables instead of secrets, as per the current setup.

## Changes

1. **Updated SSH Key Source**:
   - Changed all references from `secrets.AWS_SECRET_KEY` to `vars.AWS_SECRET_KEY`
   - Updated error messages to instruct users to add AWS_SECRET_KEY as an environment variable

## Why This Change Is Needed
The AWS_SECRET_KEY is currently stored as an environment variable in the GitHub environment, not as a secret. This PR ensures the workflow correctly references the key from the environment variables.

## How to Use
To use this workflow, you need to set up the following in your GitHub repository:

1. **Environment Variables** (in the "3d navi" environment):
   - `AWS_SERVER_IP`: Your AWS server IP address
   - `AWS_SECRET_KEY`: Your private SSH key for connecting to the AWS server

## Testing
The workflow has been tested to ensure it correctly references the AWS_SECRET_KEY from environment variables.

@msm-amit-regmi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fb13e0e0b77e4ec8803775dc5125c4c2)