### PR TITLE
Fix: Correct YAML syntax error in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,10 +114,10 @@ jobs:
           echo "Approach 4: Using explicit newlines..."
           # This is a template - replace with actual key format if known
           cat > ~/.ssh/id_rsa << 'EOL'
------BEGIN RSA PRIVATE KEY-----
-${{ vars.AWS_SECRET_KEY }}
------END RSA PRIVATE KEY-----
-EOL
+          -----BEGIN RSA PRIVATE KEY-----
+          ${{ vars.AWS_SECRET_KEY }}
+          -----END RSA PRIVATE KEY-----
+          EOL
           chmod 600 ~/.ssh/id_rsa
         fi
         


### PR DESCRIPTION
## Description
This PR fixes a YAML syntax error in the deploy.yml workflow file that was causing the workflow to fail.

## Changes
- Fixed indentation for the SSH key template in the heredoc section
- Added proper indentation to the BEGIN/END RSA PRIVATE KEY markers

## Issue
The workflow was failing with a YAML syntax error on line 117 because the heredoc content was not properly indented.

## Testing
The YAML syntax has been validated and should now parse correctly.

@msm-amit-regmi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fb13e0e0b77e4ec8803775dc5125c4c2)