### PR TITLE
Fix: Correct heredoc syntax in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,10 +114,10 @@ jobs:
           echo "Approach 4: Using explicit newlines..."
           # This is a template - replace with actual key format if known
           cat > ~/.ssh/id_rsa << 'EOL'
-          -----BEGIN RSA PRIVATE KEY-----
-          ${{ vars.AWS_SECRET_KEY }}
-          -----END RSA PRIVATE KEY-----
-          EOL
+-----BEGIN RSA PRIVATE KEY-----
+${{ vars.AWS_SECRET_KEY }}
+-----END RSA PRIVATE KEY-----
+EOL
           chmod 600 ~/.ssh/id_rsa
         fi
         


### PR DESCRIPTION
## Description
This PR fixes the heredoc syntax in the deploy.yml workflow file that was causing the workflow to fail with the error:

```
Trying multiple approaches to get a valid SSH key...
/home/runner/work/_temp/a2f1086c-e2b8-47bf-99ff-ef4058ba44e5.sh: line 189: warning: here-document at line 120 delimited by end-of-file (wanted `EOL')
/home/runner/work/_temp/a2f1086c-e2b8-47bf-99ff-ef4058ba44e5.sh: line 190: syntax error: unexpected end of file
```

## Changes
- Fixed the heredoc syntax for the SSH key template by removing indentation from the EOL delimiter
- The heredoc delimiter (EOL) must be at the beginning of the line without any indentation for proper shell script parsing

## Testing
The shell script syntax has been validated and should now parse correctly.

@msm-amit-regmi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fb13e0e0b77e4ec8803775dc5125c4c2)